### PR TITLE
fixing typo to add anchors to github site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,2 @@
 remote_theme: adr/slate
-anchor: true
+anchors: true


### PR DESCRIPTION
The current adr site doesn't create anchors due to a typo in the configuration. This PR tries to fix that.