### PR TITLE
Update GitHub actions monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Ahoy, @koppor! 👋 Just dropped another one for you. This is to ensure our GitHub actions stay current, including `lychee-action` and `markdownlint-cli2-action`. With this [Dependabot](https://docs.github.com/en/code-security/dependabot) configuration, it will automatically check action versions on the first day of each month and open pull requests if updates are available, following the same cadence as the link checker job. Feel free to let me know if you'd like any fine-tuning or adjustments.