### PR TITLE
Enable linguist detection for markdown

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.md linguist-documentation=false
+*.md linguist-detectable


### PR DESCRIPTION
This enables GitHub's Linguist to detect markdown files when computing the repo's languages. See [this repo](https://github.com/ggorlen/resources/) for an example:

![image of linguist detecting markdown](https://github.com/user-attachments/assets/53d756bb-b6ed-4e87-b914-bc511d93f4a7)