### PR TITLE
PHP repo seems to be unmaintained

### DIFF
--- a/_posts/2024-10-28-adr-tooling.md
+++ b/_posts/2024-10-28-adr-tooling.md
@@ -36,7 +36,7 @@ categories: [adr]
   - Java rewrite: [adr-j](https://github.com/adoble/adr-j)
   - ESM Node.js port: [adr-tools](https://github.com/meza/adr-tools)
   - Node.js rewrite: [adr](https://github.com/phodal/adr)
-  - PHP version: [phpadr](https://github.com/globtec/phpadr)
+  - PHP version: [phpadr](https://github.com/bellangelo/phpadr)
   - Powershell module: [adr-ps](https://github.com/rdagumampan/adr-ps)
   - Python rewrite: [adr-tools-python](https://pypi.org/project/adr-tools-python/)
   - Another Powershell module: [ArchitectureDecisionRecords](https://github.com/ajoberstar/ArchitectureDecisionRecords)


### PR DESCRIPTION
The PHP project https://github.com/globtec/phpadr seems to be unmaintained. The last commit of this project was 2 years ago with issues that have no answers.

For this reason, i started a fork https://github.com/Bellangelo/phpadr which I already started addressing some of the opened issues.

PS. There is still this open question about the project's life which I only open a couple of days back https://github.com/globtec/phpadr/issues/10