### PR TITLE
Remove empty members box in Mermaid class diagram

### DIFF
--- a/_posts/2024-10-25-adr-templates.md
+++ b/_posts/2024-10-25-adr-templates.md
@@ -9,6 +9,11 @@ categories: [adr]
 The following UML class diagram shows that many templates for ADR capturing exist, including (but not limited to) MADR, Nygardian ADRs, and Y-Statements:
 
 ```mermaid
+---
+  config:
+    class:
+      hideEmptyMembersBox: true
+---
 classDiagram
   direction TB
   class ADR {


### PR DESCRIPTION
Ahoy, @koppor! 👋 

I know it's been so long that you probably lost hope of it ever happening. Last year, Mermaid v11.4 introduced a new diagram renderer that allows to [hide empty boxes](https://github.com/mermaid-js/mermaid/issues/3139) in class diagrams. Fast-forward to just last week, GitHub finally upgraded their markdown viewer to incorporate these changes. Now, we can hide those eye-catching boxes we discussed in PR #43 a year ago.

## New Class Diagram

```mermaid
---
  config:
    class:
      hideEmptyMembersBox: true
---
classDiagram
  direction TB
  class ADR {
    <<abstract>>
  }
  ADR <|-- MADR
  ADR <|-- NygardADR
  ADR <|-- Y-Statement
  ADR <|-- OtherADRTemplate
```