### PR TITLE
docs(tooling): add Mneme HQ to architecture management tooling

### DIFF
--- a/_posts/2024-10-28-adr-tooling.md
+++ b/_posts/2024-10-28-adr-tooling.md
@@ -60,6 +60,7 @@ categories: [adr]
 
 - [ArchUnit](https://github.com/TNG/ArchUnit): unit tests for architecture
 - [docToolchain](https://doctoolchain.github.io/docToolchain/): docToolchain is an implementation of the [docs-as-code](https://www.writethedocs.org/guide/docs-as-code/) approach for software architecture plus some additional automation.
+- [Mneme HQ](https://github.com/TheoV823/mneme): enforces ADRs and architectural decisions in AI-assisted development. Hook-based pre-generation checks for Claude Code, Cursor, and Copilot — blocks violations before the AI agent writes the code.
 - [Structurizr](https://www.structurizr.com/): Structurizr is a collection of tooling to help you visualise, document and explore your software architecture using the [C4 model](https://c4model.com/).
 
 ## Interesting, but unmaintained tooling


### PR DESCRIPTION
## What

Adds [Mneme HQ](https://github.com/TheoV823/mneme) to the "Tooling related to architecture management" section of `_posts/2024-10-28-adr-tooling.md`, inserted alphabetically.

## Why

Mneme HQ is an open-source tool that enforces ADRs and architectural decisions in AI-assisted development workflows. It's hook-based and pre-generation: violations are blocked before Claude Code, Cursor, or Copilot writes the file, rather than caught in PR review.

It fits this section because it operates over architecture management (alongside ArchUnit for testing, docToolchain for docs-as-code, Structurizr for visualization) — closing a gap that's emerged as AI coding agents scale code generation beyond what manual ADR review can keep up with.

## License & compliance

- Mneme is MIT-licensed and actively maintained.
- The entry is one factual line, no marketing language.
- Inserted alphabetically (between docToolchain and Structurizr).

Happy to revise the framing or move the entry to a different subsection if maintainers prefer a different home.