### PR TITLE
docs: fix 4 typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It is based on the [Chirpy](https://chirpy.cotes.page/) theme.
 ### Updating the theme
 
 1. `git remote add chirpy-starter git@github.com:cotes2020/chirpy-starter.git`
-2. `get fetch chirpy-starter`
+2. `git fetch chirpy-starter`
 3. `git merge chirpy-starter/main`
 
 ### Icons missing

--- a/_posts/2024-10-25-adr-templates.md
+++ b/_posts/2024-10-25-adr-templates.md
@@ -62,4 +62,4 @@ Finally, you can find more explanations and examples on Medium: [Y-Statements - 
 
 Numerous other ADR formats exist, many of which are also featured in [@joelparkerhenderson's GitHub repository](https://github.com/joelparkerhenderson/architecture_decision_record).
 
-The [template](http://www.iso-architecture.org/42010/templates/) for [ISO/IEC/IEEE 42010:2011](https://en.wikipedia.org/wiki/ISO/IEC_42010), the international standard for architecture descriptions of systems and software emgineering, suggests nine information items for ADRs its Appendix A. It also identifies areas to consider when identifying key decisions.
+The [template](http://www.iso-architecture.org/42010/templates/) for [ISO/IEC/IEEE 42010:2011](https://en.wikipedia.org/wiki/ISO/IEC_42010), the international standard for architecture descriptions of systems and software engineering, suggests nine information items for ADRs its Appendix A. It also identifies areas to consider when identifying key decisions.

--- a/_posts/2024-10-28-adr-tooling.md
+++ b/_posts/2024-10-28-adr-tooling.md
@@ -24,7 +24,7 @@ categories: [adr]
 | [adr-log](https://github.com/adr/adr-log?tab=readme-ov-file#adr-log-)                                       | 2.1.2                                 | CLI to keep an `index.md` file updated with all ADRs                                                                    |
 | [ADR Manager](https://adr.github.io/adr-manager/)                                                           | 2.1.2                                 | Web-based UI connecting to GitHub to directly edit ADRs in a form-based way                                             |
 | [ADR Manager VS Code Extension](https://github.com/adr/vscode-adr-manager)                                  | 2.1.2                                 | Visual Studio Code (VS Code) extension                                                                                  |
-| [Backstage ADR plugin](https://github.com/backstage/community-plugins/tree/main/workspaces/adr/plugins/adr) | 2.1.2 and 3.x                         | plugin to explore and search ADRs within a backstage based developer portal. Search at scale across mutliple orgs/repos |
+| [Backstage ADR plugin](https://github.com/backstage/community-plugins/tree/main/workspaces/adr/plugins/adr) | 2.1.2 and 3.x                         | plugin to explore and search ADRs within a backstage based developer portal. Search at scale across multiple orgs/repos |
 | [Hugo Markdown ADR Tools](https://github.com/butonic/adr-tools)                                             | 2.1.2.                                | CLI to create and update ADRs                                                                                           |
 | [Log4brains](https://github.com/thomvaill/log4brains)                                                       | 2.1.2 without numbers in the filename | Supports both nice rendering of ADRs and creation of ADRs in a command line.                                            |
 | [pyadr](https://github.com/opinionated-digital-center/pyadr)                                                | 2.1.2                                 | CLI to help with an ADR process lifecycle (proposal/acceptance/rejection/deprecation/superseding)                       |
@@ -46,7 +46,7 @@ categories: [adr]
   - Rust rewrite: [adrs](https://github.com/joshrotenberg/adrs)
 - [adr-viewer](https://github.com/mrwilson/adr-viewer) - python application to generate a website from a set of ADRs.
 - [architectural-decision](https://github.com/cspray/architectural-decision): PHP library to create ADRs using PHP8 Attributes.
-- [Loqbooq](https://loqbooq.app): Commerical Web App with Slack integration to record ADR-inspired decision logs
+- [Loqbooq](https://loqbooq.app): Commercial Web App with Slack integration to record ADR-inspired decision logs
 - [Talo](https://github.com/canpolat/talo): CLI (and dotnet tool) to manage and export ADRs, RFCs and custom software design document types.
 
 #### Renderings


### PR DESCRIPTION
## Summary

Fix 4 typos across 3 files:

- `_posts/2024-10-28-adr-tooling.md`: mutliple → multiple
- `_posts/2024-10-28-adr-tooling.md`: Commerical → Commercial
- `_posts/2024-10-25-adr-templates.md`: emgineering → engineering
- `README.md`: get fetch → git fetch

No functional changes — comments/documentation only.