### PR TITLE
Add ADR Guard to architecture management tooling

### DIFF
--- a/_posts/2024-10-28-adr-tooling.md
+++ b/_posts/2024-10-28-adr-tooling.md
@@ -59,6 +59,7 @@ categories: [adr]
 
 ## Tooling related to architecture management
 
+- [ADR Guard](https://github.com/chohan-sarmad-ali/delivery-gates): GitHub Action that fails a pull request when watched code paths change without an architecture decision record being added or updated; template-agnostic, explicit waiver markers, no dependencies
 - [ArchUnit](https://github.com/TNG/ArchUnit): unit tests for architecture
 - [docToolchain](https://doctoolchain.github.io/docToolchain/): docToolchain is an implementation of the [docs-as-code](https://www.writethedocs.org/guide/docs-as-code/) approach for software architecture plus some additional automation.
 - [Structurizr](https://www.structurizr.com/): Structurizr is a collection of tooling to help you visualise, document and explore your software architecture using the [C4 model](https://c4model.com/).


### PR DESCRIPTION
Adds [ADR Guard](https://github.com/chohan-sarmad-ali/delivery-gates) — a GitHub Action that fails a pull request when watched code paths change without an ADR being added or updated.

**Placement reasoning:** it does not create or maintain decision files, it enforces their presence in CI — so I put it under *Tooling related to architecture management*, alphabetically before ArchUnit, which felt like the closest neighbour (enforcement rather than authoring). Happy to move it to *Any template* or reword if you see it differently.

Facts for review: template-agnostic (checks that a file under the configured ADR paths changed, not its format); waivers are explicit (`ADR-Exempt:` + reason, echoed into the job summary); ignore-lists exempt tests/docs/lockfiles by default; fails open on a missing merge base. MIT, no dependencies, [on the GitHub Marketplace](https://github.com/marketplace/actions/adr-guard).

Disclosure: I am the author.